### PR TITLE
Support case statement in function.

### DIFF
--- a/testcode/case_in_func.v
+++ b/testcode/case_in_func.v
@@ -1,0 +1,32 @@
+module TOP(IN1,SEL);
+  input IN1,SEL;
+  reg bit;
+
+
+  always @* begin
+      bit <= func1(IN1,SEL);
+  end
+
+  function func1;
+    input in1;
+    input sel;
+    case(sel)
+        'h0:
+          func1 = in1;
+        default:
+          func1 = 1'b0;
+    endcase
+  endfunction
+
+/*
+  always @* begin
+    case(SEL)
+        'h0:
+          bit = IN1;
+        default:
+          bit = 1'b0;
+    endcase
+  end
+*/
+
+endmodule

--- a/tests/dataflow_test/test_case_in_func.py
+++ b/tests/dataflow_test/test_case_in_func.py
@@ -1,0 +1,61 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) )
+from pyverilog.dataflow.dataflow_analyzer import VerilogDataflowAnalyzer
+from pyverilog.dataflow.optimizer import VerilogDataflowOptimizer
+from pyverilog.controlflow.controlflow_analyzer import VerilogControlflowAnalyzer
+codedir = '../../testcode/'
+
+expected = """\
+TOP.SEL: TOP_SEL
+TOP.md_always0.al_block0.al_functioncall0.in1: TOP_IN1
+TOP.md_always0.al_block0.al_functioncall0._rn1_func1: 1'd0
+TOP.bit: (((TOP_SEL=='d0))? TOP_IN1 : 1'd0)
+TOP.md_always0.al_block0.al_functioncall0.func1: (((TOP_SEL=='d0))? TOP_IN1 : 1'd0)
+TOP.md_always0.al_block0.al_functioncall0.sel: TOP_SEL
+TOP.md_always0.al_block0.al_functioncall0._rn0_func1: TOP_IN1
+TOP.IN1: TOP_IN1
+"""
+
+def test():
+    filelist = [codedir + 'case_in_func.v']
+    topmodule = 'TOP'
+    noreorder = False
+    nobind = False
+    include = None
+    define = None
+
+    analyzer = VerilogDataflowAnalyzer(filelist, topmodule,
+                                       noreorder=noreorder,
+                                       nobind=nobind,
+                                       preprocess_include=include,
+                                       preprocess_define=define)
+    analyzer.generate()
+
+    directives = analyzer.get_directives()
+    instances = analyzer.getInstances()
+    terms = analyzer.getTerms()
+    binddict = analyzer.getBinddict()
+
+    optimizer = VerilogDataflowOptimizer(terms, binddict)
+    optimizer.resolveConstant()
+
+    c_analyzer = VerilogControlflowAnalyzer(topmodule, terms,
+                                            binddict,
+                                            resolved_terms=optimizer.getResolvedTerms(),
+                                            resolved_binddict=optimizer.getResolvedBinddict(),
+                                            constlist=optimizer.getConstlist()
+                                            )
+
+    output = []
+    for tk in sorted(c_analyzer.resolved_terms.keys(), key=lambda x:str(x[0])):
+        tree = c_analyzer.makeTree(tk)
+        output.append(str(tk) + ': ' + tree.tocode())
+
+    rslt = '\n'.join(output) + '\n'
+
+    print(rslt)
+    assert(rslt == expected)
+
+if __name__ == '__main__':
+    test()

--- a/tests/dataflow_test/test_func.py
+++ b/tests/dataflow_test/test_func.py
@@ -1,0 +1,60 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) )
+from pyverilog.dataflow.dataflow_analyzer import VerilogDataflowAnalyzer
+from pyverilog.dataflow.optimizer import VerilogDataflowOptimizer
+from pyverilog.controlflow.controlflow_analyzer import VerilogControlflowAnalyzer
+codedir = '../../testcode/'
+
+expected = """\
+TOP.RST_X: TOP_RST_X
+TOP.md_always0.al_block0.al_if0_ELSE.al_block2.al_functioncall0.inc: (((!TOP_RST_X))? TOP_al_block0_al_block2_al_functioncall0_inc : (((!TOP_RST_X))? (((&TOP_al_block0_al_block2_al_functioncall0_inc))? 'd0 : (((!TOP_RST_X))? (TOP_al_block0_al_block2_al_functioncall0_inc+'d1) : (TOP_cnt+'d1))) : (((&TOP_al_block0_al_block2_al_functioncall0_inc))? (((!TOP_RST_X))? (TOP_al_block0_al_block2_al_functioncall0_inc+'d1) : (TOP_cnt+'d1)) : (((!TOP_RST_X))? (((&(TOP_al_block0_al_block2_al_functioncall0_inc+'d1)))? 'd0 : (((!TOP_RST_X))? (TOP_al_block0_al_block2_al_functioncall0_inc+'d1) : (TOP_cnt+'d1))) : (((&(TOP_cnt+'d1)))? 'd0 : (((!TOP_RST_X))? (TOP_al_block0_al_block2_al_functioncall0_inc+'d1) : (TOP_cnt+'d1)))))))
+TOP.md_always0.al_block0.al_if0_ELSE.al_block2.al_functioncall0._rn1_inc: (((!TOP_RST_X))? (TOP_al_block0_al_block2_al_functioncall0__rn1_inc+'d1) : (TOP_cnt+'d1))
+TOP.cnt: (((!TOP_RST_X))? 'd0 : (((!TOP_RST_X))? TOP_cnt : (((&TOP_al_block0_al_block2_al_functioncall0_inc))? 'd0 : (((!TOP_RST_X))? (TOP_cnt+'d1) : (TOP_cnt+'d1)))))
+TOP.md_always0.al_block0.al_if0_ELSE.al_block2.al_functioncall0.in: (((!TOP_RST_X))? TOP_al_block0_al_block2_al_functioncall0_in : TOP_cnt)
+TOP.CLK: TOP_CLK
+TOP.md_always0.al_block0.al_if0_ELSE.al_block2.al_functioncall0._rn0_inc: 'd0
+"""
+
+def test():
+    filelist = [codedir + 'function.v']
+    topmodule = 'TOP'
+    noreorder = False
+    nobind = False
+    include = None
+    define = None
+
+    analyzer = VerilogDataflowAnalyzer(filelist, topmodule,
+                                       noreorder=noreorder,
+                                       nobind=nobind,
+                                       preprocess_include=include,
+                                       preprocess_define=define)
+    analyzer.generate()
+
+    directives = analyzer.get_directives()
+    instances = analyzer.getInstances()
+    terms = analyzer.getTerms()
+    binddict = analyzer.getBinddict()
+
+    optimizer = VerilogDataflowOptimizer(terms, binddict)
+    optimizer.resolveConstant()
+
+    c_analyzer = VerilogControlflowAnalyzer(topmodule, terms,
+                                            binddict,
+                                            resolved_terms=optimizer.getResolvedTerms(),
+                                            resolved_binddict=optimizer.getResolvedBinddict(),
+                                            constlist=optimizer.getConstlist()
+                                            )
+
+    output = []
+    for tk in sorted(c_analyzer.resolved_terms.keys(), key=lambda x:str(x[0])):
+        tree = c_analyzer.makeTree(tk)
+        output.append(str(tk) + ': ' + tree.tocode())
+
+    rslt = '\n'.join(output) + '\n'
+
+    print(rslt)
+    assert(rslt == expected)
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
Hi shtaxxx-san,
I noticed Pyverilog fail to analyze verilog code as follows (case statement is written in function).

```verilog
  function func1;
    input in1;
    input sel;
    case(sel)
        'h0:
          func1 = in1;
        default:
          func1 = 1'b0;
    endcase
  endfunction
```

So first, I modified Bindvisitor._case change to same implementation with Signalvisitor._case.
But by only this change, case statement is not analyzed correctly.

I found that Bindvisitor.getCondlist and Bindvisitor.getFlowlist doesn't work correctly for functioncall and match_flowlist became blank. So in the following lines, tree is added in the unexpected form.

'tree = reorder.reorder(
            self.appendBranchTree(current_tree, match_flowlist, add_tree))'

So I commented out 'if frame.isFunctioncall(): break' in Bindvisitor.getCondlist and Bindvisitor.getFlowlist.

Under this modification, match_flowlist is valid (not blank), and added tree in correct form.

**But in honest, I don't understand why this line was inserted, and it can be deleted.**
Please give me advise if there are other good correction method.

With this modification, analysis result of testcode/function.v was changed. (I think previous analysis result is not correct.)