### PR TITLE
Replaced reset dection method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 2.7
+  - 3.2
+before_script:
+  - sudo apt-get install iverilog
+  - sudo pip install jinja2
+script:
+  - python --version
+  - make

--- a/testcode/decimal.v
+++ b/testcode/decimal.v
@@ -2,7 +2,7 @@ module TOP(CLK, RST);
   input CLK, RST;
   reg [7:0] cnt;
 
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK or posedge RST) begin
     if(RST) begin
       cnt <= 'd0;
     end else begin

--- a/testcode/decimal_signed.v
+++ b/testcode/decimal_signed.v
@@ -2,7 +2,7 @@ module TOP(CLK, RST);
   input CLK, RST;
   reg [7:0] cnt;
 
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK or posedge RST) begin
     if(RST) begin
       cnt <= 'd0;
     end else begin

--- a/testcode/decimal_width.v
+++ b/testcode/decimal_width.v
@@ -2,7 +2,7 @@ module TOP(CLK, RST);
   input CLK, RST;
   reg [7:0] cnt;
   
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK or posedge RST) begin
     if(RST) begin
       cnt <= 'd0;
     end else begin

--- a/testcode/irregular_reset0.v
+++ b/testcode/irregular_reset0.v
@@ -1,0 +1,15 @@
+module TOP0(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt8;
+
+  //no reset because condition is too complex
+  always @(posedge CLK or posedge RST) begin
+    if(RST && RST) begin
+      cnt8 <= 0;
+    end else begin
+      cnt8 <= 8'd1;
+    end
+  end
+
+endmodule
+

--- a/testcode/irregular_reset1.v
+++ b/testcode/irregular_reset1.v
@@ -1,0 +1,16 @@
+module TOP1(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt3,cnt1;
+
+
+  //no reset because variable is loaded
+  always @(posedge CLK or posedge RST) begin
+    if(RST) begin
+      cnt3 <= cnt1[0];
+    end else begin
+      cnt3 <= 8'd1;
+    end
+  end
+
+
+endmodule

--- a/testcode/irregular_reset2.v
+++ b/testcode/irregular_reset2.v
@@ -1,0 +1,12 @@
+module TOP2(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt4;
+  parameter zero = 0;
+
+  // no reset because it has no if branch.
+  always @(posedge CLK or posedge RST) begin
+    cnt4 <= 0;
+  end
+
+endmodule
+

--- a/testcode/irregular_reset3.v
+++ b/testcode/irregular_reset3.v
@@ -1,0 +1,15 @@
+module TOP3(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt6;
+  parameter zero = 0;
+
+  //no reset because variable is loaded.
+  always @(posedge CLK or posedge RST) begin
+    if(RST) begin
+      cnt6 <= 7'd0 + cnt1[1:0];
+    end else begin
+      cnt6 <= 8'd1;
+    end
+  end
+
+endmodule

--- a/testcode/partselect_assign.v
+++ b/testcode/partselect_assign.v
@@ -8,11 +8,11 @@ module TOP(CLK, RST, reg1, OUT);
 
   assign in1[2:1] = reg3[6:5];
 
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK) begin
     reg1 <= in1[2:1];
   end
 
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK or posedge RST) begin
     if(RST) begin
       reg3 <= 3'd0;
     end else begin

--- a/testcode/reset.v
+++ b/testcode/reset.v
@@ -20,6 +20,7 @@ module TOP(CLK, RST);
       cnt2 <= 8'd1;
 
   //not reset
+/*
   always @(posedge CLK or posedge RST) begin
     if(RST) begin
       cnt3 <= cnt1[0];
@@ -32,7 +33,7 @@ module TOP(CLK, RST);
   always @(posedge CLK or posedge RST) begin
     cnt4 <= 0;
   end
-
+*/
   //reset
   always @(posedge CLK or posedge RST) begin
     if(RST) begin
@@ -41,7 +42,7 @@ module TOP(CLK, RST);
       cnt5 <= 8'd1;
     end
   end
-
+/*
   //not reset
   always @(posedge CLK or posedge RST) begin
     if(RST) begin
@@ -50,7 +51,7 @@ module TOP(CLK, RST);
       cnt6 <= 8'd1;
     end
   end
-
+*/
   //reset
   always @(posedge CLK) begin
     if(!RST) begin
@@ -59,7 +60,7 @@ module TOP(CLK, RST);
       cnt7 <= 8'd1;
     end
   end
-
+/*
   //not reset
   always @(posedge CLK) begin
     if(RST && RST) begin
@@ -68,7 +69,7 @@ module TOP(CLK, RST);
       cnt8 <= 8'd1;
     end
   end
-
+*/
   always @(posedge CLK) begin
     if(RST[zero]) begin
       cnt10 <= 0;

--- a/testcode/signed_task.v
+++ b/testcode/signed_task.v
@@ -2,7 +2,7 @@ module TOP(CLK, RST);
   input CLK, RST;
   reg [7:0] cnt;
 
-  always @(posedge CLK or negedge RST) begin
+  always @(posedge CLK) begin
     if(RST) begin
       cnt <= $signed(cnt);
     end else begin

--- a/tests/dataflow_test/test_reset.py
+++ b/tests/dataflow_test/test_reset.py
@@ -6,6 +6,16 @@ from pyverilog.dataflow.dataflow_analyzer import VerilogDataflowAnalyzer
 codedir = '../../testcode/'
 
 expected = """\
+TOP.cnt1: sync TOP.RST[0]posedge TOP.CLK[0]
+TOP.cnt10: sync TOP.RST[0]posedge TOP.CLK[0]
+TOP.cnt2: posedge TOP.RST[0]posedge TOP.CLK[0]
+TOP.cnt5: posedge TOP.RST[0]posedge TOP.CLK[0]
+TOP.cnt7: sync TOP.RST[0]posedge TOP.CLK[0]
+TOP.sub.CLK:  [] []
+TOP.sub.RST:  [] []
+TOP.sub.cnt9: sync TOP.sub.RST[0]posedge TOP.sub.CLK[0]
+TOP.sub.zero:  [] []
+TOP.zero:  [] []
 """
 
 def test():
@@ -22,26 +32,26 @@ def test():
                                        preprocess_include=include,
                                        preprocess_define=define)
     analyzer.generate()
-    #TODO Current version is for only display.
-##    directives = analyzer.get_directives()
-##    instances = analyzer.getInstances()
-##    terms = analyzer.getTerms()
-##    binddict = analyzer.getBinddict()
-##
-##    output = []
-##    output.append(list(binddict.values())[0][0].tostr())
-##    output.append('\n')
-##
-##    rslt = ''.join(output)
-##
-##    print(rslt)
-##    for key, verb in binddict.items():
-##        if verb[0].getResetName() is None:
-##            print(str(key) + ': None')
-##        else:
-##            print(str(key) + ': ' + verb[0].getResetEdge() + str(verb[0].getResetName()) +
-##              '[' + str(verb[0].getResetBit()) + ']')
+    directives = analyzer.get_directives()
+    instances = analyzer.getInstances()
+    terms = analyzer.getTerms()
+    binddict = analyzer.getBinddict()
 
+    sens_info = []
+    for tk in sorted(binddict.keys(), key=lambda x:str(x)):
+        sens_info.append(str(tk) + ': ')
+        sens_info.append(binddict[tk][0].getResetEdge() + ' ' +
+                        str(binddict[tk][0].getResetName())+
+                        '[' + str(binddict[tk][0].getResetBit()) +']' +
+                        binddict[tk][0].getClockEdge() + ' ' +
+                        str(binddict[tk][0].getClockName()) +
+                        '[' + str(binddict[tk][0].getClockBit()) + ']')
+        sens_info.append('\n')
+
+    rslt = ''.join(sens_info)
+
+    print(rslt)
+    assert(expected == rslt)
 
 
 if __name__ == '__main__':

--- a/tests/dataflow_test/test_reset_irrregular.py
+++ b/tests/dataflow_test/test_reset_irrregular.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from pyverilog.dataflow.dataflow_analyzer import VerilogDataflowAnalyzer
+import pyverilog.utils.verror as verror
+
+codedir = '../../testcode/'
+
+
+def test():
+    filelist = [(codedir + 'irregular_reset0.v'),
+                (codedir + 'irregular_reset1.v'),
+                (codedir + 'irregular_reset2.v'),
+                (codedir + 'irregular_reset3.v')]
+##    filelist = [(codedir + 'irregular_reset4.v')]
+    topmodule = 'TOP'
+    noreorder = False
+    nobind = False
+    include = None
+    define = None
+
+    for i, file in enumerate(filelist):
+        topmodule = 'TOP' + str(i)
+        analyzer = VerilogDataflowAnalyzer(filelist, topmodule,
+                                           noreorder=noreorder,
+                                           nobind=nobind,
+                                           preprocess_include=include,
+                                           preprocess_define=define)
+        try:
+            analyzer.generate()
+        except verror.FormatError:
+            del analyzer
+        else:
+            raise Exception('Irregal reset code is passed.')
+
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
Reset dection method is replaced to if-statement-base method. (issue #14 )

modification
1)
In this method, if reset which using 'posedge' was inverted in if statement condition, exception israised.)

ex.
```verilog
  always @(posedge CLK or posedge RST) begin
    if(!RST) begin //WRONG polarity, this line must be 'RST' (bacause posedge sensitive)
      cnt <= 'd0;
    end else begin
      cnt <= cnt + 'd1;
    end
  end
```

2)
First sensitive signal, which isn't reset, will be regard as clock.
```verilog
  always @(posedge RST or posedge CK) begin //CK is clock
    if(RST) begin
      cnt <= 'd0;
    end else begin
      cnt <= cnt + 'd1;
    end
  end
```

3)
Sync reset can be detected.
```verilog
  always @(posedge CLK) begin
    if(RST) begin
      cnt <= 'd0;
    end else begin
      cnt <= cnt + 'd1;
    end
  end
```

RST is sync reset. always_info.reset_edge is 'sync.'
Conditions that are considered to be reset is in three of the following.
1. Always block has if statement.
2. Constant (not variable) is loaded in reg in first if block.
3. Condition of first if statement is simple. (That means, the condition is composed of only variable and '!' operator and '[]' operator.)
If reset signal isn't include sensitivity list, it is syncronous reset.
