### PR TITLE
Preliminary support for SystemVerilog logic, always_ff, always_comb, unique case

### DIFF
--- a/pyverilog/vparser/ast.py
+++ b/pyverilog/vparser/ast.py
@@ -458,6 +458,12 @@ class Always(Node):
         if self.statement: nodelist.append(self.statement)
         return tuple(nodelist)
 
+class AlwaysFF(Always):
+    pass
+
+class AlwaysComb(Always):
+    pass
+
 class SensList(Node):
     attr_names = ()
     def __init__(self, list, lineno=0):

--- a/pyverilog/vparser/ast.py
+++ b/pyverilog/vparser/ast.py
@@ -14,10 +14,10 @@ import re
 
 class Node(object):
     '''Abstact class for every element in parser'''
-    
+
     def children(self):
         pass
-    
+
     def show(self, buf=sys.stdout, offset=0, attrnames=False, showlineno=True):
         indent = 2
         lead = ' ' * offset
@@ -35,7 +35,7 @@ class Node(object):
         buf.write('\n')
         for c in self.children():
             c.show(buf, offset + indent, attrnames, showlineno)
-            
+
     def __eq__(self, other):
         if type(self) != type(other): return False
         self_attrs = tuple( [ getattr(self, a) for a in self.attr_names ] )
@@ -45,10 +45,10 @@ class Node(object):
         for i, c in enumerate(self.children()):
             if c != other_children[i]: return False
         return True
-    
+
     def __ne__(self, other):
         return not self.__eq__(other)
-    
+
     def __hash__(self):
         s = hash(tuple([getattr(self, a) for a in self.attr_names]))
         c = hash(self.children())
@@ -558,6 +558,8 @@ class CaseStatement(Node):
         return tuple(nodelist)
 
 class CasexStatement(CaseStatement): pass
+
+class UniqueCaseStatement(CaseStatement): pass
 
 class Case(Node):
     attr_names = ()

--- a/pyverilog/vparser/lexer.py
+++ b/pyverilog/vparser/lexer.py
@@ -43,9 +43,9 @@ class VerilogLexer(object):
     keywords = (
         'MODULE', 'ENDMODULE', 'BEGIN', 'END', 'GENERATE', 'ENDGENERATE', 'GENVAR',
         'FUNCTION', 'ENDFUNCTION', 'TASK', 'ENDTASK',
-        'INPUT', 'INOUT', 'OUTPUT', 'TRI', 'REG', 'WIRE', 'INTEGER', 'REAL', 'SIGNED',
+        'INPUT', 'INOUT', 'OUTPUT', 'TRI', 'REG', 'LOGIC', 'WIRE', 'INTEGER', 'REAL', 'SIGNED',
         'PARAMETER', 'LOCALPARAM', 'SUPPLY0', 'SUPPLY1',
-        'ASSIGN', 'ALWAYS', 'SENS_OR', 'POSEDGE', 'NEGEDGE', 'INITIAL',
+        'ASSIGN', 'ALWAYS', 'ALWAYS_FF', 'ALWAYS_COMB', 'SENS_OR', 'POSEDGE', 'NEGEDGE', 'INITIAL',
         'IF', 'ELSE', 'FOR', 'WHILE', 'CASE', 'CASEX', 'ENDCASE', 'DEFAULT',
         'WAIT', 'FOREVER', 'DISABLE', 'FORK', 'JOIN',
         )

--- a/pyverilog/vparser/lexer.py
+++ b/pyverilog/vparser/lexer.py
@@ -46,7 +46,7 @@ class VerilogLexer(object):
         'INPUT', 'INOUT', 'OUTPUT', 'TRI', 'REG', 'LOGIC', 'WIRE', 'INTEGER', 'REAL', 'SIGNED',
         'PARAMETER', 'LOCALPARAM', 'SUPPLY0', 'SUPPLY1',
         'ASSIGN', 'ALWAYS', 'ALWAYS_FF', 'ALWAYS_COMB', 'SENS_OR', 'POSEDGE', 'NEGEDGE', 'INITIAL',
-        'IF', 'ELSE', 'FOR', 'WHILE', 'CASE', 'CASEX', 'ENDCASE', 'DEFAULT',
+        'IF', 'ELSE', 'FOR', 'WHILE', 'CASE', 'CASEX', 'UNIQUE', 'ENDCASE', 'DEFAULT',
         'WAIT', 'FOREVER', 'DISABLE', 'FORK', 'JOIN',
         )
 
@@ -266,18 +266,18 @@ def dump_tokens(text):
     def my_error_func(msg, a, b):
         sys.write(msg + "\n")
         sys.exit()
-        
+
     lexer = VerilogLexer(error_func=my_error_func)
     lexer.build()
     lexer.input(text)
 
     ret = []
-    
+
     # Tokenize
     while True:
         tok = lexer.token()
         if not tok: break # No more input
         ret.append("%s %s %d %s %d\n" %
                    (tok.value, tok.type, tok.lineno, lexer.filename, tok.lexpos))
-        
+
     return ''.join(ret)

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -299,6 +299,11 @@ class VerilogParser(PLYParser):
         p[0] = p[1]
         p.set_lineno(0, p.lineno(1))
 
+    def p_sigtype_logic(self, p):
+        'sigtype : LOGIC'
+        p[0] = p[1]
+        p.set_lineno(0, p.lineno(1))
+
     def p_sigtype_wire(self, p):
         'sigtype : WIRE'
         p[0] = p[1]
@@ -458,6 +463,8 @@ class VerilogParser(PLYParser):
         | genvardecl
         | assignment
         | always
+        | always_ff
+        | always_comb
         | initial
         | instance
         | function
@@ -1254,6 +1261,14 @@ class VerilogParser(PLYParser):
         'always : ALWAYS senslist always_statement'
         p[0] = Always(p[2], p[3], lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
+
+    def p_always_ff(self, p):
+        'always_ff : ALWAYS_FF senslist always_statement'
+        p[0] = AlwaysFF(p[2], p[3], lineno=p.lineno(1))
+
+    def p_always_comb(self, p):
+        'always_comb : ALWAYS_COMB senslist always_statement'
+        p[0] = AlwaysComb(p[2], p[3], lineno=p.lineno(1))
 
     def p_sens_egde_paren(self, p):
         'senslist : AT LPAREN edgesigs RPAREN'

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -1372,6 +1372,7 @@ class VerilogParser(PLYParser):
         """basic_statement : if_statement
         | case_statement
         | casex_statement
+        | unique_case_statement
         | for_statement
         | while_statement
         | event_statement
@@ -1613,6 +1614,12 @@ class VerilogParser(PLYParser):
         'casex_statement : CASEX LPAREN case_comp RPAREN casecontent_statements ENDCASE'
         p[0] = CasexStatement(p[3], p[5], lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
+
+    def p_unique_case_statement(self, p):
+        'unique_case_statement : UNIQUE CASE LPAREN case_comp RPAREN casecontent_statements ENDCASE'
+        p[0] = UniqueCaseStatement(p[3], p[5], lineno=p.lineno(1))
+        p.set_lineno(0, p.lineno(1))
+
 
     def p_case_comp(self, p):
         'case_comp : expression'


### PR DESCRIPTION
This adds basic support for the System Verilog constructs `logic`, `always_ff`, and `always_comb` to the parser.

I needed these specific changes to be able to read in a System Verilog file. I'm not sure if there's more that needs to be done in the rest of the code base to complete support for these constructs. Let me know and I'd be happy to help.