### PR TITLE
Req1. add parsing rule, integer declaration and initialization.

### DIFF
--- a/pyverilog/vparser/ast.py
+++ b/pyverilog/vparser/ast.py
@@ -272,15 +272,18 @@ class StringConst(Constant):
 class Variable(Value):
     attr_names = ('name', 'signed')
 
-    def __init__(self, name, width=None, signed=False, dimensions=None, lineno=0):
+    def __init__(self, name, value=None, width=None, signed=False, dimensions=None, lineno=0):
         self.lineno = lineno
         self.name = name
+        self.value = value
         self.width = width
         self.signed = signed
         self.dimensions = dimensions
 
     def children(self):
         nodelist = []
+        if self.value:
+            nodelist.append(self.value)
         if self.width:
             nodelist.append(self.width)
         if self.dimensions:

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -711,7 +711,7 @@ class VerilogParser(PLYParser):
         p.set_lineno(0, p.lineno(1))
 
     def p_integername_init(self, p):
-        'integername: ID EQUALS rvalue'
+        'integername : ID EQUALS rvalue'
         p[0] = (p[1], p[3])
         p.set_lineno(0, p.lineno(1))
 

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -682,21 +682,21 @@ class VerilogParser(PLYParser):
     # Integer
     def p_integerdecl(self, p):
         'integerdecl : INTEGER integernamelist SEMICOLON'
-        intlist = [Integer(r,
+        intlist = [Integer(rname, rvalue,
                            Width(msb=IntConst('31', lineno=p.lineno(2)),
                                  lsb=IntConst('0', lineno=p.lineno(2)),
                                  lineno=p.lineno(2)),
-                           signed=True, lineno=p.lineno(2)) for r in p[2]]
+                           signed=True, lineno=p.lineno(2)) for rname, rvalue in p[2]]
         p[0] = Decl(tuple(intlist), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_integerdecl_signed(self, p):
         'integerdecl : INTEGER SIGNED integernamelist SEMICOLON'
-        intlist = [Integer(r,
+        intlist = [Integer(rname, rvalue, 
                            Width(msb=IntConst('31', lineno=p.lineno(3)),
                                  lsb=IntConst('0', lineno=p.lineno(3)),
                                  lineno=p.lineno(3)),
-                           signed=True, lineno=p.lineno(3)) for r in p[2]]
+                           signed=True, lineno=p.lineno(3)) for rname, rvalue in p[2]]
         p[0] = Decl(tuple(intlist), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
@@ -710,9 +710,14 @@ class VerilogParser(PLYParser):
         p[0] = (p[1],)
         p.set_lineno(0, p.lineno(1))
 
+    def p_integername_init(self, p):
+        'integername: ID EQUALS rvalue'
+        p[0] = (p[1], p[3])
+        p.set_lineno(0, p.lineno(1))
+
     def p_integername(self, p):
         'integername : ID'
-        p[0] = p[1]
+        p[0] = (p[1], None)
         p.set_lineno(0, p.lineno(1))
 
     # Real


### PR DESCRIPTION
In verilog, not only integer declaration but integer declaration and initialization is also available. 
Such as, 
```verilog
integer i = 0;
```

but Pyverilog could not parse such statement. 
I added parsing rule for it. 
Unfortunately, I modified Variable class in ast.py to save the initial value, but it can be different if there is better solution.