### PR TITLE
add parsing rule, function integer ID

### DIFF
--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -2058,6 +2058,15 @@ class VerilogParser(PLYParser):
                         p[4], lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
+    def p_function_integer(self, p):
+        'function : FUNCTION INTEGER ID SEMICOLON function_statement ENDFUNCTION'
+        p[0] = Function(p[3],
+                        Width(IntConst('31', lineno=p.lineno(1)),
+                              IntConst('0', lineno=p.lineno(1)),
+                              lineno=p.lineno(1)),
+                        p[5], lineno=p.lineno(1))
+        p.set_lineno(0, p.lineno(1))
+
     def p_function_statement(self, p):
         'function_statement : funcvardecls function_calc'
         p[0] = p[1] + (p[2],)


### PR DESCRIPTION
Integer type return function is also correct in verilog grammar.

Such as,
```verilog
function integer clog2;
input integer in;
begin 
  in = in - 1;
  for (clog2 = 0; in > 0; clog2=clog2+1)
    in = in >> 1;
end
endfunction
```

Added parsing rule for such function declaration.