### PR TITLE
Adding basic support for CASEZ statements

### DIFF
--- a/pyverilog/vparser/ast.py
+++ b/pyverilog/vparser/ast.py
@@ -882,6 +882,10 @@ class CasexStatement(CaseStatement):
     pass
 
 
+class CasezStatement(CaseStatement):
+    pass
+
+
 class UniqueCaseStatement(CaseStatement):
     pass
 

--- a/pyverilog/vparser/lexer.py
+++ b/pyverilog/vparser/lexer.py
@@ -56,7 +56,7 @@ class VerilogLexer(object):
         'INPUT', 'INOUT', 'OUTPUT', 'TRI', 'REG', 'LOGIC', 'WIRE', 'INTEGER', 'REAL', 'SIGNED',
         'PARAMETER', 'LOCALPARAM', 'SUPPLY0', 'SUPPLY1',
         'ASSIGN', 'ALWAYS', 'ALWAYS_FF', 'ALWAYS_COMB', 'ALWAYS_LATCH', 'SENS_OR', 'POSEDGE', 'NEGEDGE', 'INITIAL',
-        'IF', 'ELSE', 'FOR', 'WHILE', 'CASE', 'CASEX', 'UNIQUE', 'ENDCASE', 'DEFAULT',
+        'IF', 'ELSE', 'FOR', 'WHILE', 'CASE', 'CASEX', 'CASEZ', 'UNIQUE', 'ENDCASE', 'DEFAULT',
         'WAIT', 'FOREVER', 'DISABLE', 'FORK', 'JOIN',
     )
 

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -1413,6 +1413,7 @@ class VerilogParser(PLYParser):
         """basic_statement : if_statement
         | case_statement
         | casex_statement
+        | casez_statement
         | unique_case_statement
         | for_statement
         | while_statement
@@ -1654,6 +1655,11 @@ class VerilogParser(PLYParser):
     def p_casex_statement(self, p):
         'casex_statement : CASEX LPAREN case_comp RPAREN casecontent_statements ENDCASE'
         p[0] = CasexStatement(p[3], p[5], lineno=p.lineno(1))
+        p.set_lineno(0, p.lineno(1))
+
+    def p_casez_statement(self, p):
+        'casez_statement : CASEZ LPAREN case_comp RPAREN casecontent_statements ENDCASE'
+        p[0] = CasezStatement(p[3], p[5], lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_unique_case_statement(self, p):
@@ -2092,6 +2098,7 @@ class VerilogParser(PLYParser):
         | while_statement
         | case_statement
         | casex_statement
+        | casez_statement
         | block
         | namedblock
         """
@@ -2161,6 +2168,7 @@ class VerilogParser(PLYParser):
         | while_statement
         | case_statement
         | casex_statement
+        | casez_statement
         | block
         | namedblock
         """


### PR DESCRIPTION
I'm using Pyverilog to obtain the boundary description of a Verilog module (ports, parameters, etc.) - unfortunately when a 'CASEZ' statement is used, it it causing the AST parser to fail:

```
Generating LALR tables
WARNING: 183 shift/reduce conflicts
Syntax error
Traceback (most recent call last):
  File "test.py", line 13, in <module>
    file.parse()
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/parser.py", line 2274, in parse
    ast = self.parser.parse(text, debug=debug)
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/parser.py", line 77, in parse
    return self.parser.parse(text, lexer=self.lexer, debug=debug)
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/ply/yacc.py", line 265, in parse
    return self.parseopt_notrack(input,lexer,debug,tracking,tokenfunc)
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/ply/yacc.py", line 1047, in parseopt_notrack
    tok = self.errorfunc(errtoken)
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/parser.py", line 2246, in p_error
    self._coord(p.lineno))
  File ".../venv/lib/python3.7/site-packages/pyverilog/vparser/plyparser.py", line 55, in _parse_error
    raise ParseError("%s: %s" % (coord, msg))
pyverilog.vparser.plyparser.ParseError: :6: before: (
```
This can be triggered by a module definition as simple as:
```verilog
module my_mod(input clk, input rst, input [3:0] vector, output reg [3:0] data);
always @(posedge clk or posedge rst) begin
    if (rst) begin
        data <= 1'b0;
    end else begin
        casez (vector)
            4'b??1?: data <= vector;
            4'b?1??: data <= ~vector;
            4'b1??0: data <= 4'h0;
            default: data <= 4'hF;
        endcase
    end
end
endmodule
```
The fix I'm pushing is just enough to get the AST parse to complete - I have not widely tested it, nor pushed the changes into the code generator.