### PR TITLE
[PARTSELECT PLUS MINUS FIX] Fixed the MSB or LSB computation for the …

### DIFF
--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -854,15 +854,13 @@ class VerilogParser(object):
 
     def p_lpartselect_lpointer_plus(self, p):
         'lpartselect : pointer LBRACKET expression PLUSCOLON expression RBRACKET'
-        inc_value = p[5]
-        inc_value.value = str(int(inc_value.value)-1)
+        inc_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Plus(p[3], inc_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpartselect_lpointer_minus(self, p):
         'lpartselect : pointer LBRACKET expression MINUSCOLON expression RBRACKET'
-        dec_value = p[5]
-        dec_value.value = str(int(dec_value.value)-1)
+        dec_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Minus(p[3], dec_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -871,15 +871,13 @@ class VerilogParser(object):
 
     def p_lpartselect_plus(self, p):
         'lpartselect : identifier LBRACKET expression PLUSCOLON expression RBRACKET'
-        inc_value = p[5]
-        inc_value.value = str(int(inc_value.value)-1)
+        inc_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Plus(p[3], inc_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpartselect_minus(self, p):
         'lpartselect : identifier LBRACKET expression MINUSCOLON expression RBRACKET'
-        dec_value = p[5]
-        dec_value.value = str(int(dec_value.value)-1)
+        dec_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Minus(p[3], dec_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
@@ -1221,16 +1219,14 @@ class VerilogParser(object):
 
     def p_partselect_plus(self, p):
         'partselect : identifier LBRACKET expression PLUSCOLON expression RBRACKET'
-        inc_value = p[5]
-        inc_value.value = str(int(inc_value.value)-1)
+        inc_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Plus(
             p[3], inc_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_partselect_minus(self, p):
         'partselect : identifier LBRACKET expression MINUSCOLON expression RBRACKET'
-        dec_value = p[5]
-        dec_value.value = str(int(dec_value.value)-1)
+        dec_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Minus(
             p[3], dec_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
@@ -1242,16 +1238,14 @@ class VerilogParser(object):
 
     def p_partselect_pointer_plus(self, p):
         'partselect : pointer LBRACKET expression PLUSCOLON expression RBRACKET'
-        inc_value = p[5]
-        inc_value.value = str(int(inc_value.value)-1)
+        inc_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Plus(
             p[3], inc_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_partselect_pointer_minus(self, p):
         'partselect : pointer LBRACKET expression MINUSCOLON expression RBRACKET'
-        dec_value = p[5]
-        dec_value.value = str(int(dec_value.value)-1)
+        dec_value = Minus(p[5], IntConst('1'))
         p[0] = Partselect(p[1], p[3], Minus(
             p[3], dec_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -854,12 +854,16 @@ class VerilogParser(object):
 
     def p_lpartselect_lpointer_plus(self, p):
         'lpartselect : pointer LBRACKET expression PLUSCOLON expression RBRACKET'
-        p[0] = Partselect(p[1], p[3], Plus(p[3], p[5]), lineno=p.lineno(1))
+        inc_value = p[5]
+        inc_value.value = str(int(inc_value.value)-1)
+        p[0] = Partselect(p[1], p[3], Plus(p[3], inc_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpartselect_lpointer_minus(self, p):
         'lpartselect : pointer LBRACKET expression MINUSCOLON expression RBRACKET'
-        p[0] = Partselect(p[1], p[3], Minus(p[3], p[5]), lineno=p.lineno(1))
+        dec_value = p[5]
+        dec_value.value = str(int(dec_value.value)-1)
+        p[0] = Partselect(p[1], p[3], Minus(p[3], dec_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpartselect(self, p):
@@ -869,12 +873,16 @@ class VerilogParser(object):
 
     def p_lpartselect_plus(self, p):
         'lpartselect : identifier LBRACKET expression PLUSCOLON expression RBRACKET'
-        p[0] = Partselect(p[1], p[3], Plus(p[3], p[5]), lineno=p.lineno(1))
+        inc_value = p[5]
+        inc_value.value = str(int(inc_value.value)-1)
+        p[0] = Partselect(p[1], p[3], Plus(p[3], inc_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpartselect_minus(self, p):
         'lpartselect : identifier LBRACKET expression MINUSCOLON expression RBRACKET'
-        p[0] = Partselect(p[1], p[3], Minus(p[3], p[5]), lineno=p.lineno(1))
+        dec_value = p[5]
+        dec_value.value = str(int(dec_value.value)-1)
+        p[0] = Partselect(p[1], p[3], Minus(p[3], dec_value), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_lpointer(self, p):
@@ -1215,14 +1223,18 @@ class VerilogParser(object):
 
     def p_partselect_plus(self, p):
         'partselect : identifier LBRACKET expression PLUSCOLON expression RBRACKET'
+        inc_value = p[5]
+        inc_value.value = str(int(inc_value.value)-1)
         p[0] = Partselect(p[1], p[3], Plus(
-            p[3], p[5], lineno=p.lineno(1)), lineno=p.lineno(1))
+            p[3], inc_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_partselect_minus(self, p):
         'partselect : identifier LBRACKET expression MINUSCOLON expression RBRACKET'
+        dec_value = p[5]
+        dec_value.value = str(int(dec_value.value)-1)
         p[0] = Partselect(p[1], p[3], Minus(
-            p[3], p[5], lineno=p.lineno(1)), lineno=p.lineno(1))
+            p[3], dec_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_partselect_pointer(self, p):
@@ -1232,14 +1244,18 @@ class VerilogParser(object):
 
     def p_partselect_pointer_plus(self, p):
         'partselect : pointer LBRACKET expression PLUSCOLON expression RBRACKET'
+        inc_value = p[5]
+        inc_value.value = str(int(inc_value.value)-1)
         p[0] = Partselect(p[1], p[3], Plus(
-            p[3], p[5], lineno=p.lineno(1)), lineno=p.lineno(1))
+            p[3], inc_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_partselect_pointer_minus(self, p):
         'partselect : pointer LBRACKET expression MINUSCOLON expression RBRACKET'
+        dec_value = p[5]
+        dec_value.value = str(int(dec_value.value)-1)
         p[0] = Partselect(p[1], p[3], Minus(
-            p[3], p[5], lineno=p.lineno(1)), lineno=p.lineno(1))
+            p[3], dec_value, lineno=p.lineno(1)), lineno=p.lineno(1))
         p.set_lineno(0, p.lineno(1))
 
     def p_pointer(self, p):


### PR DESCRIPTION
Fixed the MSB or LSB computation for the indexed vector partselect for Verilog. The second value is not a direct offset but the width of the selected part. So the value needs to be decreased by 1 before adding or subtracting it from the base.

Example Code: 
module.v
```verilog
module top
  (
   input wire clk, 
   input wire rstn,
   input wire [31:0] in,
   input wire [31:0] key_in,
   output reg [31:0] out
  );

  reg taint [31:0] key;

  assign key = key_in;

  always
  begin
    out[15-:16] = in[15-:16] & key[0+:16];
    out[31:16] = in[15:0] | key[15:0];
  end
endmodule
```

The first indices for OUT result in 15 (MSB) and -1 (LSB). Same for the first in. Additionally, 0+:16 results in 0 (LSB) and 16 (MSB).

Also contributed and a big thanks to:
@GorgeousWalrus 