### PR TITLE
fix: unexpected keyword argument `reorder`

### DIFF
--- a/examples/example_graphgen.py
+++ b/examples/example_graphgen.py
@@ -98,7 +98,7 @@ def main():
 
     for target in options.searchtarget:
         graphgen.generate(target, walk=options.walk, identical=options.identical,
-                          step=options.step, reorder=options.reorder, delay=options.delay)
+                          step=options.step, do_reorder=options.reorder, delay=options.delay)
 
     graphgen.draw()
 


### PR DESCRIPTION
In the definition of the `VerilogGraphGenerator` class, one of the arguments of its `generate` method is `do_reorder`:
https://github.com/PyHDI/Pyverilog/blob/81838bc463d17148ef6872af34eb27585ee349ba/pyverilog/dataflow/graphgen.py#L57
However, in the `example_graphgen.py` file, this argument is mistakenly referred to as `reorder`.
https://github.com/PyHDI/Pyverilog/blob/81838bc463d17148ef6872af34eb27585ee349ba/examples/example_graphgen.py#L100-L101
So when running `python3 pyverilog/examples/example_graphgen.py -t top -s top.led test.v`, I encountered error messages that are as follows:
```sh
Generating LALR tables
WARNING: 183 shift/reduce conflicts
Traceback (most recent call last):
  File "/path/to/pyverilog-demo/pyverilog/examples/example_graphgen.py", line 107, in <module>
    main()
  File "/path/to/pyverilog-demo/pyverilog/examples/example_graphgen.py", line 100, in main
    graphgen.generate(target, walk=options.walk, identical=options.identical,
TypeError: VerilogGraphGenerator.generate() got an unexpected keyword argument 'reorder'
```