### PR TITLE
Fix declassign regs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.out
 parsetab.py
+build/
+*.egg-info/

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -630,7 +630,7 @@ class VerilogParser(object):
                              signed=signed, lineno=lineno))
 
         # Declassign of reg is the same as an initial block with blocking
-        # assignment (others are the same as constants).
+        # assignment.
         if 'reg' in sigtypes:
             decls.append(Initial(BlockingSubstitution(*(assign.children()))))
         else:

--- a/pyverilog/vparser/parser.py
+++ b/pyverilog/vparser/parser.py
@@ -628,7 +628,13 @@ class VerilogParser(object):
         if 'reg' in sigtypes:
             decls.append(Reg(name=name, width=width,
                              signed=signed, lineno=lineno))
-        decls.append(assign)
+
+        # Declassign of reg is the same as an initial block with blocking
+        # assignment (others are the same as constants).
+        if 'reg' in sigtypes:
+            decls.append(Initial(BlockingSubstitution(*(assign.children()))))
+        else:
+            decls.append(assign)
         return decls
 
     def typecheck_declassign(self, sigtypes):


### PR DESCRIPTION
# Problem:
In Verilog, the statement

```
reg my_reg = 0;
```

is the same as

```
reg my_reg;
initial my_reg = 0;
```

whereas in the current HEAD, the statement above
is translated to
```
reg my_reg; assign my_reg = 0;
```

# Solution

This commit fixes this bug by converting the assignment ast node to a blocking assignment wrapped in an initial block.